### PR TITLE
Make g:probe_cache_dir more flexible

### DIFF
--- a/autoload/probe/file.vim
+++ b/autoload/probe/file.vim
@@ -128,7 +128,7 @@ endfunction
 
 function! s:save_cache(filename, files)
     if !isdirectory(g:probe_cache_dir)
-        cal mkdir(g:probe_cache_dir)
+        cal mkdir(g:probe_cache_dir, 'p')
     endif
     cal writefile(a:files, a:filename)
 endfunction

--- a/plugin/probe.vim
+++ b/plugin/probe.vim
@@ -9,8 +9,10 @@ if !exists('g:probe_ignore_files')
 endif
 
 if !exists('g:probe_cache_dir')
-    let g:probe_cache_dir = expand('$HOME/.probe_cache')
+    let g:probe_cache_dir = '$HOME/.probe_cache'
 endif
+
+let g:probe_cache_dir = expand(g:probe_cache_dir)
 
 if !exists('g:probe_max_file_cache_size')
     let g:probe_max_file_cache_size = 100000


### PR DESCRIPTION
- Expand user's `g:probe_cache_dir` value so variables like `$HOME` and
  `~` can be used.
- Use `makedir()`'s `p` argument so it can create intermediate
  directories as required.